### PR TITLE
fix: remove the list view template override

### DIFF
--- a/apis_acdhch_default_settings/settings.py
+++ b/apis_acdhch_default_settings/settings.py
@@ -303,8 +303,6 @@ APIS_LIST_VIEWS_ALLOWED = False
 APIS_DETAIL_VIEWS_ALLOWED = False
 MAX_AGE = 60 * 60
 
-APIS_LIST_VIEW_TEMPLATE = "browsing/generic_list.html"
-
 APIS_IIIF_WORK_KIND = "IIIF"
 APIS_IIIF_ENT_IIIF_REL = "has iiif image"
 APIS_IIIF_SERVER = "https://iiif.acdh.oeaw.ac.at/"


### PR DESCRIPTION
apis-rdf-core in version 0.3.0 now updated the settings for the default
list view template. The `browsing/generic_list.html` template was
removed and the new value does not need to be overridden anymore.
