### PR TITLE
fix: add apis_core.core to installed apps

### DIFF
--- a/apis_acdhch_default_settings/settings.py
+++ b/apis_acdhch_default_settings/settings.py
@@ -79,6 +79,7 @@ INSTALLED_APPS = [
     "django_filters",
     "django_tables2",
     "rest_framework",
+    "apis_core.core",
     "apis_core.apis_entities",
     "apis_core.apis_metainfo",
     "apis_core.apis_relations",


### PR DESCRIPTION
apis-core-rdf v0.5 uses the apiscore templatetag which resides in the
`apis_core.core` app - so we have to add this one to the list of
INSTALLED_APPS.
