### PR TITLE
fix: drop charts dependency

### DIFF
--- a/apis_acdhch_default_settings/settings.py
+++ b/apis_acdhch_default_settings/settings.py
@@ -88,7 +88,6 @@ INSTALLED_APPS = [
     "rest_framework.authtoken",
     # "drf_yasg",
     "drf_spectacular",
-    "charts",
     "csvexport",
     "apis_ontology",
 ]


### PR DESCRIPTION
Starting from v0.6 APIS does not contain charts code anymore, so we can
drop it.
