### PR TITLE
ci: add GH_TOKEN to ci workflow

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -21,4 +21,6 @@ jobs:
           release-type: python
           package-name: apis-acdhch-default-settings
       - run: gh workflow run publish.yml
+        env:
+          GH_TOKEN: ${{ github.token }}
         if: ${{ steps.release.outputs.release_created }}


### PR DESCRIPTION
gh says: To use GitHub CLI in a GitHub Actions workflow, set the
GH_TOKEN environment variable
