### PR TITLE
fix: add crispy_bootstrap4 to list of installed apps

### DIFF
--- a/apis_acdhch_default_settings/settings.py
+++ b/apis_acdhch_default_settings/settings.py
@@ -77,6 +77,7 @@ INSTALLED_APPS = [
     "django.contrib.staticfiles",
     "reversion",
     "crispy_forms",
+    "crispy_bootstrap4",
     "django_filters",
     "django_tables2",
     "rest_framework",


### PR DESCRIPTION
This will be used starting from apis-core-rdf v0.9.0
