### PR TITLE
fix: set drf DEFAULT_PERMISSION_CLASSES to model permission

### DIFF
--- a/apis_acdhch_default_settings/settings.py
+++ b/apis_acdhch_default_settings/settings.py
@@ -134,10 +134,7 @@ REST_FRAMEWORK = {
     "DEFAULT_PAGINATION_CLASS": "rest_framework.pagination.LimitOffsetPagination",
     "PAGE_SIZE": 50,
     "DEFAULT_PERMISSION_CLASSES": (
-        # "rest_framework.permissions.DjangoModelPermissions",
-        # "rest_framework.permissions.IsAuthenticated",
-        "rest_framework.permissions.DjangoObjectPermissions",
-        # use IsAuthenticated for every logged in user to have global edit rights
+        "rest_framework.permissions.DjangoModelPermissions",
     ),
     "DEFAULT_AUTHENTICATION_CLASSES": (
         "rest_framework.authentication.TokenAuthentication",


### PR DESCRIPTION
we don't use guardian anymore, therefore there are not object
permissions
