### PR TITLE
fix: TEMPLATES: remove apis_ontology/templates from DIRS

### DIFF
--- a/apis_acdhch_default_settings/settings.py
+++ b/apis_acdhch_default_settings/settings.py
@@ -174,7 +174,7 @@ ROOT_URLCONF = "apis_acdhch_default_settings.urls"
 TEMPLATES = [
     {
         "BACKEND": "django.template.backends.django.DjangoTemplates",
-        "DIRS": [os.path.join(BASE_DIR, "apis_ontology", "templates")],
+        "DIRS": [],
         "APP_DIRS": True,
         "OPTIONS": {
             "context_processors": [


### PR DESCRIPTION
`apis_ontology` is an app, therefore it is already looking for templates
in its templates folder
