### PR TITLE
fix: add 'generic' app to INSTALLED_APPS

### DIFF
--- a/apis_acdhch_default_settings/settings.py
+++ b/apis_acdhch_default_settings/settings.py
@@ -84,6 +84,7 @@ INSTALLED_APPS = [
     "apis_core.apis_metainfo",
     "apis_core.apis_relations",
     "apis_core.apis_vocabularies",
+    "apis_core.generic",
     "rest_framework.authtoken",
     # "drf_yasg",
     "drf_spectacular",


### PR DESCRIPTION
Include new app introduced in apis-core-rdf v0.10.0 release