### PR TITLE
fix(spectacular): set DEFAULT_GENERATOR_CLASS

### DIFF
--- a/apis_acdhch_default_settings/settings.py
+++ b/apis_acdhch_default_settings/settings.py
@@ -101,6 +101,7 @@ SPECTACULAR_SETTINGS: Dict[str, Any] = {
     "DESCRIPTIOPN": "Provides access to the main APIS data-model endpoints.",
     "LICENSE": {"name": "MIT License", "url": "https://www.mit.edu/~amini/LICENSE.md"},
     "VERSION": "0.13",
+    "DEFAULT_GENERATOR_CLASS": 'apis_core.generic.generators.CustomSchemaGenerator'
 }
 
 


### PR DESCRIPTION
APIS ships a default generator class since v0.16.0, lets use it in
our default setups.

Closes: #84
