### PR TITLE
fix(template): make imprint url handling more robust

### DIFF
--- a/apis_acdhch_default_settings/templates/base.html
+++ b/apis_acdhch_default_settings/templates/base.html
@@ -1,5 +1,5 @@
 {% extends "base.html" %}
-
 {% block imprint %}
-<a href="{% url 'django_acdhch_functions:imprint' %}">Imprint | Impressum</a>
+    {% url "imprint" as imprint_url %}
+    {% if imprint_url %}<a href="{{ imprint_url }}">Imprint | Impressum</a>{% endif %}
 {% endblock imprint %}


### PR DESCRIPTION
The imprint url should not point to django_acdhch_functions, this was a
leftover from importing the code from django_acdhch_functions. This was
replaced with the correct route and an `as` syntax, which does not raise
a NoReverseMatch exception.
