### PR TITLE
fix(urls): drop inclusion of webpage app in urls

### DIFF
--- a/apis_acdhch_default_settings/urls.py
+++ b/apis_acdhch_default_settings/urls.py
@@ -17,10 +17,6 @@ urlpatterns = [
     path("admin/", admin.site.urls),
 ]
 
-if "webpage" in settings.INSTALLED_APPS:
-    urlpatterns.append(path("", include("webpage.urls", namespace="webpage")))
-    handler404 = "webpage.views.handler404"
-
 if "apis_bibsonomy" in settings.INSTALLED_APPS:
     urlpatterns.append(
         path("bibsonomy/", include("apis_bibsonomy.urls", namespace="bibsonomy"))


### PR DESCRIPTION
The webpape app is not used anymore in APIS and thus it makes sense to
remove it from the routing configuration.

Closes: #114
