### PR TITLE
feat(settings): allow to set DEBUG from environment

### DIFF
--- a/apis_acdhch_default_settings/settings.py
+++ b/apis_acdhch_default_settings/settings.py
@@ -242,6 +242,10 @@ LOGGING = {
     },
 }
 
+# https://docs.djangoproject.com/en/5.0/ref/settings/#std-setting-DEBUG
+if debug := os.environ.get("DJANGO_DEBUG", False):
+    DEBUG = debug.lower() == "true"
+
 # Our deployment infrastructure sets the GITLAB_ENVIRONMENT_URL to the
 # repository from which the instance is deployed. Lets reuse this
 # information to set the repository url in APIS


### PR DESCRIPTION
This commit introduces a check for the DJANGO_DEBUG environment
variable, which allows us to set the DEBUG setting of Django.
