### PR TITLE
feat(settings)!: drop apis_relations from INSTALLED_APPS

### DIFF
--- a/apis_acdhch_default_settings/settings.py
+++ b/apis_acdhch_default_settings/settings.py
@@ -49,7 +49,6 @@ INSTALLED_APPS = [
     "rest_framework",
     "apis_ontology",
     "apis_acdhch_default_settings",
-    "apis_core.apis_relations",
     "apis_core.apis_entities",
     "apis_core.apis_metainfo",
     "apis_core.apis_vocabularies",


### PR DESCRIPTION
`apis_relations` will be dropped from the next apis-core-rdf release, so
it makes sense to remove it from the default settings now.
