### PR TITLE
feat(settings): (re)add Content Security Policy setting

### DIFF
--- a/apis_acdhch_default_settings/settings.py
+++ b/apis_acdhch_default_settings/settings.py
@@ -87,6 +87,9 @@ CSP_DEFAULT_SRC = (
     "*.openstreetmap.org",
 )
 
+# Content Security Policy settings
+CSP_FRAME_ANCESTORS = ["https://*.pages.oeaw.ac.at/"]
+
 # django-crispy-forms settings
 # https://django-crispy-forms.readthedocs.io/en/latest/install.html#template-packs
 CRISPY_TEMPLATE_PACK = "bootstrap5"


### PR DESCRIPTION
Add `CSP_FRAME_ANCESTORS` variable with web address to ÖAW-hosted GitLab pages to allow embedding of
APIS apps contents in GitLab-hosted presentations (iframes).

---

Follow-up to https://github.com/acdh-oeaw/apis-acdhch-default-settings/pull/138#issuecomment-2621510940.

This setting [was added to TBF](https://github.com/acdh-oeaw/apis-instance-tbf/blob/16eb9b828a3eea14b4b8fafd01846945289bff3b/apis_ontology/settings.py#L16-L18) and seems to be working from what I can tell Though I'm not sure if the presentation which recently embedded part of the app would need to be redeployed. Not linking it here because it wasn't given publicly, but @sennierer knows where it's at.
