### PR TITLE
ci: run add-to-project workflow also on PRs

### DIFF
--- a/.github/workflows/add-to-project.yml
+++ b/.github/workflows/add-to-project.yml
@@ -1,10 +1,13 @@
 # SPDX-FileCopyrightText: 2024 K Kollmann
 # SPDX-License-Identifier: MIT
 
-name: Add repository issues to Prosnet project
+name: Add issues, PRs to Prosnet project
 
 on:
   issues:
+    types:
+      - opened
+  pull_request:
     types:
       - opened
 


### PR DESCRIPTION
Add `pull_request` trigger to `add-to-project`
workflow so both (new/opened) issues and PRs
are added to the Prosnet project.
Update workflow `name` to reflect this change.

Closes: #162