### PR TITLE
feat(settings): introduce a separate CSP setting for images

### DIFF
--- a/apis_acdhch_default_settings/settings.py
+++ b/apis_acdhch_default_settings/settings.py
@@ -86,6 +86,7 @@ CSP_DEFAULT_SRC = (
     "unpkg.com",
     "*.openstreetmap.org",
 )
+CSP_IMG_SRC = ["'self'", "*.acdh.oeaw.ac.at", "data:"]
 
 # django-crispy-forms settings
 # https://django-crispy-forms.readthedocs.io/en/latest/install.html#template-packs


### PR DESCRIPTION
This also incldues `data:` which is used by Bootstrap 5
