### PR TITLE
fix(settings): drop apis_override_select2js from INSTALLED_APPS

### DIFF
--- a/apis_acdhch_default_settings/settings.py
+++ b/apis_acdhch_default_settings/settings.py
@@ -32,7 +32,6 @@ BASE_DIR = Path(__file__).resolve().parent.parent
 # put apis_override_select2js at the beginning of the list
 # to make its static files weigh more than from the other apps
 INSTALLED_APPS = [
-    "apis_override_select2js",
     "dal",
     "dal_select2",
     "django.contrib.admin",


### PR DESCRIPTION
(it's not a dependency of apis-core anymore)
