### PR TITLE
build: add urls to project metadata

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,8 @@
+[project.urls]
+source = "https://github.com/acdh-oeaw/apis-acdhch-default-settings"
+issues = "https://github.com/acdh-oeaw/apis-acdhch-default-settings/issues"
+changelog = "https://github.com/acdh-oeaw/apis-acdhch-default-settings/releases"
+
 [tool.poetry]
 name = "apis-acdhch-default-settings"
 version = "2.2.2"


### PR DESCRIPTION
Add `[project.urls]` setting to `pyproject.toml` in an attempt to make Dependabot generate clickable links to the project repository in its pull requests.
This should also generate clickable "Project links" on the project's package page on PyPI.

---

I just noticed (again) that the link to the repo is missing from Dependabot's prompts to update the dependency, so decided to fix this based on an internal discussion which was had a while ago.