### PR TITLE
build: move, convert project/package settings

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,15 +1,20 @@
+[project]
+name = "apis-acdhch-default-settings"
+description = "Default settings for APIS instances at the ACDH-CH"
+authors = [
+    { name = "Birger Schacht", email = "<birger.schacht@oeaw.ac.at>" },
+]
+license = { text = "MIT" }
+readme = "README.md"
+dynamic = [ "version", "dependencies" ]
+
 [project.urls]
 source = "https://github.com/acdh-oeaw/apis-acdhch-default-settings"
 issues = "https://github.com/acdh-oeaw/apis-acdhch-default-settings/issues"
 changelog = "https://github.com/acdh-oeaw/apis-acdhch-default-settings/releases"
 
 [tool.poetry]
-name = "apis-acdhch-default-settings"
 version = "2.2.2"
-description = "Default settings for APIS instances at the ACDH-CH"
-authors = ["Birger Schacht <birger.schacht@oeaw.ac.at>"]
-license = "MIT"
-readme = "README.md"
 
 [tool.poetry.dependencies]
 python = "^3.11"


### PR DESCRIPTION
Move main project metadata from `[tool.poetry]` section to new `[project]` section and update the format of individual settings which require it (like `authors`, `license`).
This change attempts to rectify the breaking of the config file's formatting when `[project.urls]` was introduced without an overall `[project]` section.
Not yet included is a conversion of the project dependencies to the Python/PyPA default format; for the moment, they are included dynamically.

Resolves: #175