### PR TITLE
fix(settings): add resources used by leaflet to CSP_IMG_SRC

### DIFF
--- a/apis_acdhch_default_settings/settings.py
+++ b/apis_acdhch_default_settings/settings.py
@@ -86,7 +86,7 @@ CSP_DEFAULT_SRC = (
     "unpkg.com",
     "*.openstreetmap.org",
 )
-CSP_IMG_SRC = ["'self'", "*.acdh.oeaw.ac.at", "data:"]
+CSP_IMG_SRC = ["'self'", "*.acdh.oeaw.ac.at", "data:", "*.openstreetmap.org", "cdnjs.cloudflare.com"]
 
 # Content Security Policy settings
 CSP_FRAME_ANCESTORS = ["https://*.pages.oeaw.ac.at/"]


### PR DESCRIPTION
Leaflet uses tiles from openstreetmap.org and icons from
cdnjs.cloudflare.com, so we need to allow those via CSP.
