### PR TITLE
build: readd version constraints lost on migration from poetry to uv

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,12 +7,12 @@ requires-python = ">=3.11"
 authors = [{ name = "Birger Schacht", email = "birger.schacht@oeaw.ac.at" }]
 license = "MIT"
 dependencies = [
-    "sentry-sdk>=1.26.0",
-    "dj-database-url>=2.0.0",
+    "sentry-sdk>=1.26.0,<2.0",
+    "dj-database-url>=2.0.0,<3.0",
     "django-allow-cidr>=0.6,<0.8",
-    "django-csp>=3.7",
+    "django-csp>=3.7,<4.0",
     "whitenoise>=5.2,<7.0",
-    "django-auth-ldap>=4.6.0",
+    "django-auth-ldap>=4.6.0,<5.0",
     "opentelemetry-instrumentation-asgi",
     "opentelemetry-instrumentation-wsgi",
     "opentelemetry-instrumentation-django",
@@ -20,7 +20,7 @@ dependencies = [
     "opentelemetry-instrumentation-psycopg2",
     "opentelemetry-exporter-otlp",
     "opentelemetry-distro",
-    "django-removals>=1.0.5",
+    "django-removals>=1.0.5,<=2.0",
 ]
 
 [build-system]


### PR DESCRIPTION
th poetry dependency list used the caret character to limit some of the
dependencies. we mimic this constraint using an upper limit.
