### PR TITLE
feat(templates): add a monitoring variable to the meta tags

### DIFF
--- a/apis_acdhch_default_settings/templates/base.html
+++ b/apis_acdhch_default_settings/templates/base.html
@@ -1,5 +1,11 @@
 {% extends "base.html" %}
 {% load i18n %}
+
+{% block meta %}
+{{ block.super }}
+<meta name="monitoring" content="Icinga Check">
+{% endblock meta %}
+
 {% block imprint %}
     {% url "imprint" as imprint_url %}
     {% if imprint_url %}<a href="{{ imprint_url }}">{% translate "Imprint" %}</a>{% endif %}


### PR DESCRIPTION
We should use this meta tag for monitoring instead of the `Title
Placeholder` string.
