### PR TITLE
build: readd project urls

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,10 @@ dependencies = [
     "opentelemetry-distro",
     "django-removals>=1.0.5,<=2.0",
 ]
+[project.urls]
+source = "https://github.com/acdh-oeaw/apis-acdhch-default-settings"
+changelog = "https://github.com/acdh-oeaw/apis-acdhch-default-settings/blob/main/CHANGELOG.md"
+issues = "https://github.com/acdh-oeaw/apis-acdhch-default-settings/issues"
 
 [build-system]
 requires = ["hatchling"]


### PR DESCRIPTION
now that we use `uv` that should be safe
