### PR TITLE
feat(settings): add context processor for lang vars

### DIFF
--- a/apis_acdhch_default_settings/settings.py
+++ b/apis_acdhch_default_settings/settings.py
@@ -132,6 +132,7 @@ TEMPLATES = [
         "OPTIONS": {
             "context_processors": [
                 "django.template.context_processors.debug",
+                "django.template.context_processors.i18n",
                 "django.template.context_processors.request",
                 "django.contrib.auth.context_processors.auth",
                 "django.contrib.messages.context_processors.messages",


### PR DESCRIPTION
Add built-in `django.template.context_processors.i18n` context processor to `TEMPLATES` setting to make
language-related variables `LANGUAGES`, `LANGUAGE_BIDI`, `LANGUAGE_CODE` available in templates/`RequestContext`.

Closes: #210