### PR TITLE
fix(templates): move footer override into correct file

### DIFF
--- a/apis_acdhch_default_settings/templates/base.html
+++ b/apis_acdhch_default_settings/templates/base.html
@@ -4,18 +4,3 @@
     {{ block.super }}
     <meta name="monitoring" content="Icinga Check">
 {% endblock meta %}
-{% block footer-center %}
-    <a href="https://www.oeaw.ac.at/acdh/" target="_blank">
-        <img id="logo"
-             class="icon"
-             alt="ACDH Logo"
-             title="Austrian Centre for Digital Humanities (ACDH) of the Austrian Academy of Sciences"
-             src="https://fundament.acdh.oeaw.ac.at/common-assets/images/acdh_logo.svg" />
-    </a>
-{% endblock footer-center %}
-{% block imprint %}
-    {% url "imprint" as imprint_url %}
-    {% if imprint_url %}
-        <a href="{{ imprint_url }}">{% translate "Imprint" %}</a>
-    {% endif %}
-{% endblock imprint %}

--- a/apis_acdhch_default_settings/templates/partials/footer.html
+++ b/apis_acdhch_default_settings/templates/partials/footer.html
@@ -1,0 +1,17 @@
+{% extends "partials/footer.html" %}
+{% load i18n %}
+{% block footer-center %}
+    <a href="https://www.oeaw.ac.at/acdh/" target="_blank">
+        <img id="logo"
+             class="icon"
+             alt="ACDH Logo"
+             title="Austrian Centre for Digital Humanities (ACDH) of the Austrian Academy of Sciences"
+             src="https://fundament.acdh.oeaw.ac.at/common-assets/images/acdh_logo.svg" />
+    </a>
+{% endblock footer-center %}
+{% block imprint %}
+    {% url "imprint" as imprint_url %}
+    {% if imprint_url %}
+        <a href="{{ imprint_url }}">{% translate "Imprint" %}</a>
+    {% endif %}
+{% endblock imprint %}


### PR DESCRIPTION
We can not override blocks in included templates. Instead we have to
override the included template separatly.
