### PR TITLE
fix(querysets): change default filter for E53_PlaceExternalAutocomplete

### DIFF
--- a/apis_acdhch_default_settings/querysets.py
+++ b/apis_acdhch_default_settings/querysets.py
@@ -20,7 +20,7 @@ class E53_PlaceExternalAutocomplete(ExternalAutocomplete):
         ),
         LobidAutocompleteAdapter(
             params={
-                "filter": "type:PlaceOrGeographicName",
+                "filter": "type:TerritorialCorporateBodyOrAdministrativeUnit",
                 "format": "json:preferredName",
             }
         ),


### PR DESCRIPTION
The `PlaceOrGeographicName` type gave too many results that were not the
place types we wanted, `TerritorialCorporateBodyOrAdministrativeUnit`
seems to be a better fit.

Closes: #240
