### PR TITLE
feat(settings): add uris to INSTALLED_APPS

### DIFF
--- a/apis_acdhch_default_settings/settings.py
+++ b/apis_acdhch_default_settings/settings.py
@@ -32,6 +32,7 @@ INSTALLED_APPS = [
     "apis_core.generic",
     "apis_core.collections",
     "apis_core.history",
+    "apis_core.uris",
     "apis_core.relations",
     "apis_core.apis_entities",
     "apis_core.apis_metainfo",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ dependencies = [
     "opentelemetry-distro",
     "django-removals>=1.0.5,<=2.0",
     "django>=5",
-    "apis-core-rdf>=0.40.0",
+    "apis-core-rdf>=0.52.0",
     "requests>=2",
     "django-auditlog>=3.1.2",
     "apis-acdhch-django-auditlog>=0.2.1",


### PR DESCRIPTION
Add `apis_core.uris` following `apis-core-rdf` release `v0.52.0`, which moved the `Uri` model to a separate app.

Closes: #247